### PR TITLE
Grammar improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Expose [MySQL Protocol](http://imysql.com/mysql-internal-manual/text-protocol.ht
 var driver = new MySqlDriver(option);
 driver.Open();
 
-var reader = driver.Query("selct 1"); // COM_QUERY
+var reader = driver.Query("select 1"); // COM_QUERY
 while (reader.Read())
 {
     var v = reader.GetInt32(0);

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Performance enhancements
 * Directly deserialize from binary to number.
 * Avoid ADO.NET abstraction, expose primitive API and ADO.NET should be built on top of it.
 * Micro ORM(like Dapper) built on top of primitive MySQL API.
-* Fast query text parsing deliver with `ref char[]` buffer(avoiding usage of `StringBuilder` and `String`) - [FastQueryParser](https://github.com/neuecc/MySqlSharp/blob/master/src/MySqlSharp/Internal/FastQueryParser.cs).
+* Fast query text parsing with `ref char[]` buffer(avoiding usage of `StringBuilder` and `String`) - [FastQueryParser](https://github.com/neuecc/MySqlSharp/blob/master/src/MySqlSharp/Internal/FastQueryParser.cs).
 * Use prepared-statement cache like [Npgsql approach](http://www.roji.org/prepared-statements-in-npgsql-3-2).
 
 MySQL [X-Protocol](https://dev.mysql.com/doc/internals/en/x-protocol.html) increases server-client performance but [Amazon Aurora](https://aws.amazon.com/rds/aurora/details/) and other services do not implement X-Protocol yet.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Extremely Fast MySQL Driver for C#, work in progress.
 
 Async does not mean fast, I thought database driver is the serialization problem over TCP. I've released two fastest serializers [ZeroFormatter](https://github.com/neuecc/ZeroFormatter) and [MessagePack for C#](https://github.com/neuecc/MessagePack-CSharp), this MySQL driver is using there optimization techiniques.
 
-![image](https://user-images.githubusercontent.com/46207/29018376-ce3ecba0-7b95-11e7-90f0-d32d7c80b04b.png)
+| Method              |     Mean | Error |  Gen 0 | Allocated |
+|---------------------|---------:|------:|-------:|----------:|
+| MySqlSharp          | 893.2 us |    NA |      - |     968 B |
+| MySqlConnector      | 863.0 us |    NA | 9.7656 |   69153 B |
+| AsyncMysqlConnector | 843.8 us |    NA | 5.8594 |   47000 B |
 
 It shows 1/50 memory usage decrease(not optimized yet, I should reduce means perfs)
 


### PR DESCRIPTION
Hey, I found your library very interesting and I wanted to make the README a bit more readable.

I used the build in markdown table functionality to avoid usage of an image, the outcome can be seen here: https://github.com/txdv/MySqlSharp/blob/grammar-improvements/README.md

I also fixed the example (select instead of selct).

And I changed the sentences for better readability.

I hope you like the changes, let me know if you have any comments.

Also, the last commit is a separate one because I did not know what you wanted to say with the word "deliver" in that sentence, can you explain it a bit further? 